### PR TITLE
Move config file into config directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM scratch
 
+RUN ["mkdir", "-p", "/config"]
+
 COPY gnatsd /gnatsd
-COPY gnatsd.conf /gnatsd.conf
+COPY gnatsd.conf /config/gnatsd.conf
 
 # Expose client, management, and cluster ports
 EXPOSE 4222 8222 6222
 
 # Run via the configuration file
-ENTRYPOINT ["/gnatsd", "-c", "/gnatsd.conf"]
+ENTRYPOINT ["/gnatsd", "-c", "/config/gnatsd.conf"]
 CMD []


### PR DESCRIPTION
This will allow downstream users to override the
config file within image by mounting a volume
containing a custom `gnatsd.conf` file.

Refs dokku/dokku-nats#2
