### PR TITLE
Allow to override entrypoint with other commands.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM scratch
 
 COPY gnatsd /gnatsd
-COPY gnatsd.conf /gnatsd.conf
+COPY gnatsd.conf gnatsd.conf
 
 # Expose client, management, and cluster ports
 EXPOSE 4222 8222 6222
 
 # Run via the configuration file
-ENTRYPOINT ["/gnatsd", "-c", "/gnatsd.conf"]
-CMD []
+ENTRYPOINT ["/gnatsd"]
+CMD ["-c", "gnatsd.conf"]


### PR DESCRIPTION
The current entry point doesn't allow to override the location
of the configuration, making it very hard to use any other
command to run gnatsd with.

This change allows users to start the container with an clean
command giving them access to change all configuration options,
beside the location of the configuration file.

You can test this change by running the image I pushed to the registry. Examples:

```
$ docker run calavera/nats
$ docker run calavera/nats gnatsd
$ docker run -v my-config.conf:/gnatsd.conf calavera/nats
$ docker run -v /etc/nats:/etc/nats calavera/nats gnatsd -c /etc/nats/nats.conf
```

Signed-off-by: David Calavera <david.calavera@gmail.com>