### PR TITLE
Updated Windows variants

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -28,9 +28,18 @@ ID=$(docker create nats-builder)
 # Update the local binary.
 docker cp $ID:/go/bin/gnatsd .
 
+# Windows variant
+docker build -t nats-builder-win -f $TEMP/Dockerfile.win64 $TEMP
+ID_WIN=$(docker create nats-builder-win)
+docker cp $ID_WIN:/go/src/github.com/nats-io/gnatsd/gnatsd.exe .
+cp gnatsd.exe windows/nanoserver
+cp gnatsd.exe windows/windowsservercore
+rm gnatsd.exe
+
 # Cleanup.
 rm -fr $TEMP
 docker rm -f $ID
+docker rm -f $ID_WIN
 docker rmi nats-builder
-
+docker rmi nats-builder-win
 echo "Done."

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -1,5 +1,10 @@
 FROM microsoft/nanoserver
 
+# The NAT Server will look for this environment variable.
+# When set, it prevents the use of the service API to detect
+# if it is running in interactive mode or not, which is
+# failing in the context of a Docker container.
+# (https://github.com/nats-io/gnatsd/issues/543)
 ENV NATS_WIN_CONTAINER=1
 
 WORKDIR c:/gnatsd

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -1,16 +1,9 @@
-# escape=`
 FROM microsoft/nanoserver
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV NATS_VERSION="v1.0.0"
-
-# Download and expand released version
-RUN Invoke-WebRequest -OutFile gnatsd.zip "https://github.com/nats-io/gnatsd/releases/download/$($env:NATS_VERSION)/gnatsd-$($env:NATS_VERSION)-windows-amd64.zip" -UseBasicParsing ; `
-    Expand-Archive gnatsd.zip -DestinationPath C:\ ; `
-    Move-Item "C:/gnatsd-$($env:NATS_VERSION)-windows-amd64" 'c:/gnatsd'; `
-    Remove-Item gnatsd.zip
+ENV NATS_WIN_CONTAINER=1
 
 WORKDIR c:/gnatsd
+COPY gnatsd.exe gnatsd.exe
 COPY gnatsd.conf gnatsd.conf
 
 # Expose client, management, and cluster ports

--- a/windows/nanoserver/Dockerfile
+++ b/windows/nanoserver/Dockerfile
@@ -5,7 +5,7 @@ FROM microsoft/nanoserver
 # if it is running in interactive mode or not, which is
 # failing in the context of a Docker container.
 # (https://github.com/nats-io/gnatsd/issues/543)
-ENV NATS_WIN_CONTAINER=1
+ENV NATS_DOCKERIZED=1
 
 WORKDIR c:/gnatsd
 COPY gnatsd.exe gnatsd.exe

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -1,16 +1,9 @@
-# escape=`
 FROM microsoft/windowsservercore
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV NATS_VERSION="v1.0.0"
-
-# Download and expand released version
-RUN Invoke-WebRequest -OutFile gnatsd.zip "https://github.com/nats-io/gnatsd/releases/download/$($env:NATS_VERSION)/gnatsd-$($env:NATS_VERSION)-windows-amd64.zip" -UseBasicParsing ; `
-    Expand-Archive gnatsd.zip -DestinationPath C:\ ; `
-    Move-Item "C:/gnatsd-$($env:NATS_VERSION)-windows-amd64" 'c:/gnatsd'; `
-    Remove-Item gnatsd.zip
+ENV NATS_WIN_CONTAINER=1
 
 WORKDIR c:/gnatsd
+COPY gnatsd.exe gnatsd.exe
 COPY gnatsd.conf gnatsd.conf
 
 # Expose client, management, and cluster ports

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -5,7 +5,7 @@ FROM microsoft/windowsservercore
 # if it is running in interactive mode or not, which is
 # failing in the context of a Docker container.
 # (https://github.com/nats-io/gnatsd/issues/543)
-ENV NATS_WIN_CONTAINER=1
+ENV NATS_DOCKERIZED=1
 
 WORKDIR c:/gnatsd
 COPY gnatsd.exe gnatsd.exe

--- a/windows/windowsservercore/Dockerfile
+++ b/windows/windowsservercore/Dockerfile
@@ -1,5 +1,10 @@
 FROM microsoft/windowsservercore
 
+# The NAT Server will look for this environment variable.
+# When set, it prevents the use of the service API to detect
+# if it is running in interactive mode or not, which is
+# failing in the context of a Docker container.
+# (https://github.com/nats-io/gnatsd/issues/543)
 ENV NATS_WIN_CONTAINER=1
 
 WORKDIR c:/gnatsd


### PR DESCRIPTION
update.sh will now also use gnatsd/Dockerfile.win64 to build the
executable and copy it to windows sub directories.
These directories have now an updated Dockerfile that simply
copy the local gnatsd.exe into the Docker image (instead of
downloading from release pages).