### PR TITLE
Update readme and add update script

### DIFF
--- a/2.1.0/scratch/get-scratch-bins.sh
+++ b/2.1.0/scratch/get-scratch-bins.sh
@@ -6,6 +6,13 @@ if [[ "$(pwd)" != *"/scratch" ]]; then
 	exit 1
 fi
 
+go_version="${1}"
+if [[ "${go_version}" == "" ]]; then
+	echo "usage: ${0} <go version>"
+	echo "       ${0} 1.12.9"
+	exit 1
+fi
+
 # get-scratch-bins.sh builds different architecture NATS server binaries from
 # source inside of a Go container. These binaries are then exposed to the host
 # and checked into this repo.
@@ -17,7 +24,7 @@ fi
 # Note 'EOF' means that the heredoc is sent as a string literal. No variable
 # expansion happens from the super shell.
 
-docker run --interactive --rm --volume $(pwd):/out golang:1.12.9 bash << 'EOF'
+docker run --interactive --rm --volume "$(pwd)":/out "golang:${go_version}" bash << 'EOF'
 	set -ex
 	mkdir -p /go/src/github.com/nats-io/nats-server
 	cd /go/src/github.com/nats-io/nats-server

--- a/README.md
+++ b/README.md
@@ -2,49 +2,103 @@
 
 [![License][License-Image]][License-Url]
 
-This is the Git repo of the official Docker image for [nats]. See the Hub page
-for the full readme on how to use this Docker image and for information
-regarding contributing and issues.
+This is the repo for building the official [NATS server Docker images]. If you
+just want to use NATS server, then head over to [Docker Hub]. You don't need
+this repo.
 
-## nats-docker Windows Variants
+The rest of this readme is for image maintainers.
 
-These Dockerfiles are for building NATS images for Windows Docker containers.
+## Directory structure
 
-The Windows variants are tags of the official [nats] image:
-
-* `nats:nanoserver` - a lightweight option built on
-  `mcr.microsoft.com/windows/nanoserver:1803`
-* `nats:nanoserver-1809` - a lightweight option built on
-  `mcr.microsoft.com/windows/nanoserver:1809`
-* `nats:windowsservercore` - a full Windows OS version built on
-  `mcr.microsoft.com/windows/servercore:ltsc2016`
-
-You should use `nats:nanoserver`, unless you are extending this image and need
-the extra functionality available in `nats:windowsservercore`.
-
-## Updating
+The directories are structured in a way such that each NATS server release has
+a directory. Each release version has a number of base image variants, such as
+scratch on Linux or nanoserver on Windows.
 
 ```
-# Rename the directory.
-mv 2.1.0 2.1.1
-
-# Alternatively, copy it into a new directory to support multiple versions.
-cp -r 2.1.0 2.1.1
-
-# Update the NATS server version with this command.
-sed --in-place 's/SERVER_VERSION 2.1.0/SERVER_VERSION 2.1.1/g' \
-	$(grep --files-with-matches --recursive "SERVER_VERSION" *)
-
-# Update the Go version in build image with this command.
-sed --in-place 's/golang:1.12.9/golang:1.12.10/g' \
-	$(grep --files-with-matches --recursive "golang:" *)
+nats-docker/
+├── 1.2.3
+│   ├── image variant
+└───└── image variant
 ```
 
-## License
+For the most part, image variant Dockerfiles will download the official NATS
+server [release binaries] when building the server image and `COPY` a default
+configuration file.
 
-Unless otherwise noted, the NATS source files are distributed
-under the Apache Version 2.0 license found in the LICENSE file.
+The Linux scratch image is special though. Since it's mostly air, we
+build the binaries locally. The scratch directory contains subdirectories for
+different architectures.
 
-[License-Url]: https://www.apache.org/licenses/LICENSE-2.0
+## Updating NATS server version
+
+First, make sure you've published a new NATS server git tag and make sure the
+[release binaries] are ready to download.
+
+Next, run this command. `update-server-version.sh` will update Dockerfiles and
+anything else to the version you specify.
+
+In addition, the scratch binaries will be built. We will fetch the server
+version tag and use the specified Go version to build the binaries.
+
+```
+usage ./update-server-version.sh <server version> <go version>
+      ./update-server-version.sh 2.1.1 1.13.1
+```
+
+This script doesn't update everything though. Here are some other things you
+may or may not want to update.
+
+* The Ubuntu host version used for CI.
+* The Windows host versions used for CI.
+
+After you've updated everything that needs updating. Submit a PR to this repo.
+Make sure CI passes.
+
+## Publishing on Docker Hub
+
+To publish your new changes to Docker Hub. Head over to
+[docker-library/official-images]. You'll need to update the [nats IMF] file.
+
+IMF stands for Internet Message Format. It's the format that Docker chose to
+declare images, instead of something like YAML.
+
+You'll need to update the git commit in this file.
+
+```
+GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
+```
+
+Also handy to know, if you're testing and haven't merged your PR in
+nats-io/nats-docker. You can tell Docker to pull a commit from a different
+branch like this.
+
+```
+GitFetch: refs/heads/mybranch
+GitCommit: 710f0ed18645d78e97fa7fd8cdf9b80dbe936eb6
+```
+
+Docker images will be built in the order they're specified in the IMF file.
+This detail is especially important for the Windows images. Nanoserver images
+copy a binary from servercore images. This means a servercore image *must* come
+before a corresponding nanoserver image.
+
+```
+Tags: 2.1.0-servercore1803, servercore1803
+Architectures: windows-amd64
+Directory: 2.1.0/servercore1803
+Constraints: windowsservercore-1803
+
+Tags: 2.1.0-nanoserver1803, nanoserver1803
+Architectures: windows-amd64
+Directory: 2.1.0/nanoserver1803
+Constraints: nanoserver-1803, windowsservercore-1803
+```
+
+
+[Docker Hub]: https://hub.docker.com/_/nats
+[docker-library/official-images]: https://github.com/docker-library/official-images
 [License-Image]: https://img.shields.io/badge/License-Apache2-blue.svg
-[nats]: https://registry.hub.docker.com/_/nats/
+[License-Url]: https://www.apache.org/licenses/LICENSE-2.0
+[nats IMF]: https://github.com/docker-library/official-images/blob/master/library/nats
+[NATS server Docker images]: https://hub.docker.com/_/nats
+[release binaries]: https://github.com/nats-io/nats-server/releases

--- a/update-server-version.sh
+++ b/update-server-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -e
+
+# sedi is a cross platform sed. It's necessary because macOS and Linux sed are
+# different. :(
+sedi () {
+	sed --version >/dev/null 2>&1 && sed --in-place -- "$@" || sed -i "" "$@"
+}
+
+if [[ "$(pwd)" != *"nats-docker" ]]; then
+	echo "$(basename ${0}) must be run from the repo top level"
+	exit 1
+fi
+
+current_version=$(ls -1 | sort | head -n 1)
+new_version="${1}"
+go_version="${2}"
+if [[ "${new_version}" == "" ]] || [[ "${go_version}" == "" ]]; then
+	echo "usage: ${0} <server version> <go version>"
+	echo "       ${0} 2.1.0 1.12.9"
+	exit 1
+fi
+
+echo "current version: ${current_version}"
+echo "new version: ${new_version}"
+echo "go version: ${go_version}"
+
+echo "updating files..."
+files=$(grep --recursive --binary-files=without-match --files-with-matches "NATS_SERVER ${current_version}" ./*)
+sedi "s/NATS_SERVER ${current_version}/NATS_SERVER ${new_version}/g" $files
+
+files=$(grep --recursive --binary-files=without-match --files-with-matches "nats:${current_version}" ./*)
+sedi "s/nats:${current_version}/nats:${new_version}/g" $files
+
+echo "rebuilding scratch binaries..."
+(
+	cd "${current_version}/scratch"
+	./get-scratch-bins.sh "${go_version}"
+)
+
+echo "renaming directory..."
+git mv "${current_version}" "${new_version}"


### PR DESCRIPTION
This change updates the repo readme with all the new info I learned
about building the NATS server Docker images.

In addition, it also adds a script to easily update the server version.