### PR TITLE
Update Alpine Dockerfile

### DIFF
--- a/2.1.0/alpine3.10/Dockerfile
+++ b/2.1.0/alpine3.10/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.10
 
 ENV NATS_SERVER 2.1.0
+ENV NATS_SERVER_SHA256 a4012cac52715dbc693dbc3a98b90369b132416b12a67f9bcfb24c18d1efcbd6
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
@@ -14,18 +15,18 @@ RUN set -eux; \
 	esac; \
 	\
 	wget -O nats-server.zip "https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-linux-${natsArch}.zip"; \
+	echo "${NATS_SERVER_SHA256}  nats-server.zip" | sha256sum -c -; \
 	\
 	apk add --no-cache ca-certificates; \
 	apk add --no-cache --virtual buildtmp unzip; \
 	\
 	unzip nats-server.zip "nats-server-v${NATS_SERVER}-linux-${natsArch}/nats-server"; \
 	rm nats-server.zip; \
-	mv "nats-server-v${NATS_SERVER}-linux-${natsArch}/nats-server" /; \
+	mv "nats-server-v${NATS_SERVER}-linux-${natsArch}/nats-server" /usr/local/bin; \
 	rmdir "nats-server-v${NATS_SERVER}-linux-${natsArch}"; \
 	\
 	apk del --no-cache --no-network buildtmp
 
-COPY nats-server.conf /nats-server.conf
+COPY nats-server.conf /etc/nats/nats-server.conf
 EXPOSE 4222 8222 6222
-ENTRYPOINT ["/nats-server"]
-CMD ["--config", "nats-server.conf"]
+CMD ["nats-server"]

--- a/2.1.0/scratch/Dockerfile
+++ b/2.1.0/scratch/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
-COPY --from=nats:2.1.0-alpine3.10 /nats-server /nats-server
+COPY --from=nats:2.1.0-alpine3.10 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 EXPOSE 4222 8222 6222
 ENTRYPOINT ["/nats-server"]

--- a/README.md
+++ b/README.md
@@ -41,8 +41,15 @@ In addition, the scratch binaries will be built. We will fetch the server
 version tag and use the specified Go version to build the binaries.
 
 ```
-usage ./update-server-version.sh <server version>
-      ./update-server-version.sh 2.1.1
+usage: ./update-server-version.sh <server version> <linux release sha256>
+       ./update-server-version.sh 2.1.0 68e656b251e67e8358bef8483ab0d51c6619f3e7a1a9f0e75838d41ff368f728
+```
+
+You can get the Linux release SHA256 from the [release binaries] page or by
+running this command.
+
+```
+shasum -a 256 nats-server.zip
 ```
 
 This script doesn't update everything though. Here are some other things you

--- a/update-server-version.sh
+++ b/update-server-version.sh
@@ -14,21 +14,26 @@ fi
 
 current_version=$(ls -1 | sort | head -n 1)
 new_version="${1}"
-if [[ "${new_version}" == "" ]]; then
-	echo "usage: ${0} <server version>"
-	echo "       ${0} 2.1.0"
+linux_release_sha256="${2}"
+if [[ "${new_version}" == "" ]] || [[ "${linux_release_sha256}" == "" ]]; then
+	echo "usage: ${0} <server version> <linux release sha256>"
+	echo "       ${0} 2.1.0 68e656b251e67e8358bef8483ab0d51c6619f3e7a1a9f0e75838d41ff368f728"
 	exit 1
 fi
 
 echo "current version: ${current_version}"
 echo "new version: ${new_version}"
+echo "linux release sha256: ${linux_release_sha256}"
 
 echo "updating files..."
-files=$(grep --recursive --binary-files=without-match --files-with-matches "NATS_SERVER ${current_version}" ./*)
-sedi "s/NATS_SERVER ${current_version}/NATS_SERVER ${new_version}/g" $files
+files=$(grep --recursive --binary-files=without-match --files-with-matches --extended-regexp "NATS_SERVER [0-9]+\.[0-9]+\.[0-9]+" ./*)
+sedi "s/NATS_SERVER [0-9]\+\.[0-9]\+\.[0-9]\+/NATS_SERVER ${new_version}/g" $files
 
-files=$(grep --recursive --binary-files=without-match --files-with-matches "nats:${current_version}" ./*)
-sedi "s/nats:${current_version}/nats:${new_version}/g" $files
+files=$(grep --recursive --binary-files=without-match --files-with-matches --extended-regexp "NATS_SERVER_SHA256 [a-z0-9]{64}\b" ./*)
+sedi "s/NATS_SERVER_SHA256 [a-z0-9]\{64\}\>/NATS_SERVER_SHA256 ${linux_release_sha256}/g" $files
+
+files=$(grep --recursive --binary-files=without-match --files-with-matches --extended-regexp "nats:[0-9]+\.[0-9]+\.[0-9]+" ./*)
+sedi "s/nats:[0-9]\+\.[0-9]\+\.[0-9]\+/nats:${new_version}/g" $files
 
 echo "renaming directory..."
 git mv "${current_version}" "${new_version}"


### PR DESCRIPTION
This change verifies the downloaded release SHA and also changes the
entrypoint logic.

Based on feedback from
https://github.com/docker-library/official-images/pull/6842