### PR TITLE
Refactor for macOS compatibility

### DIFF
--- a/update-server-version.sh
+++ b/update-server-version.sh
@@ -1,20 +1,36 @@
 #!/usr/bin/env bash
 set -e
 
-# sedi is a cross platform sed. It's necessary because macOS and Linux sed are
-# different. :(
-sedi () {
-	sed --version >/dev/null 2>&1 && sed --in-place -- "$@" || sed -i "" "$@"
+replace_env() {
+	pat="s/NATS_SERVER [0-9]+\.[0-9]+\.[0-9]+/NATS_SERVER ${1}/g"
+	if [[ $OSTYPE == "darwin"* ]]; then
+		sed -i'.sedibak' -E "$pat" $2
+		find . -name "*.sedibak" -delete
+	fi
+	if [[ $OSTYPE == "linux"* ]]; then
+		sed --in-place --regexp-extended "$pat" $2
+	fi
+}
+
+replace_tag() {
+	pat="s/nats:[0-9]+\.[0-9]+\.[0-9]+/nats:${1}/g"
+	if [[ $OSTYPE == "darwin"* ]]; then
+		sed -i'.sedibak' -E "$pat" $2
+		find . -name "*.sedibak" -delete
+	fi
+	if [[ $OSTYPE == "linux"* ]]; then
+		sed --in-place --regexp-extended "$pat" $2
+	fi
 }
 
 if [[ "$(pwd)" != *"nats-docker" ]]; then
-	echo "$(basename ${0}) must be run from the repo top level"
+	echo "$(basename "${0}") must be run from the repo top level"
 	exit 1
 fi
 
 current_version=$(ls -1 | sort | head -n 1)
 new_version="${1}"
-if [[ "${new_version}" == "" ]]; then
+if [[ ${new_version} == "" ]]; then
 	echo "usage: ${0} <server version>"
 	echo "       ${0} 2.1.0"
 	exit 1
@@ -25,10 +41,10 @@ echo "new version: ${new_version}"
 
 echo "updating files..."
 files=$(grep --recursive --binary-files=without-match --files-with-matches --extended-regexp "NATS_SERVER [0-9]+\.[0-9]+\.[0-9]+" ./*)
-sedi "s/NATS_SERVER [0-9]\+\.[0-9]\+\.[0-9]\+/NATS_SERVER ${new_version}/g" $files
+replace_env "$new_version" "$files"
 
 files=$(grep --recursive --binary-files=without-match --files-with-matches --extended-regexp "nats:[0-9]+\.[0-9]+\.[0-9]+" ./*)
-sedi "s/nats:[0-9]\+\.[0-9]\+\.[0-9]\+/nats:${new_version}/g" $files
+replace_tag "$new_version" "$files"
 
 echo "renaming directory..."
 git mv "${current_version}" "${new_version}"


### PR DESCRIPTION
Currently, update-server-version.sh doesn't work on macOS. This change
allows the script to work on macOS.

I was also going to add macOS CI, but licensing doesn't allow me.
https://github.community/t5/GitHub-Actions/Why-is-Docker-not-installed-on-macOS/m-p/39758#M3952

You should be able to verify this works on macOS by doing the following.

```
./update-server-version.sh 2.1.0
./tests/build-images.sh
./tests/run-images.sh
```