### PR TITLE
[FIXED] Alpine Dockerfile missing entrypoint and using config file

### DIFF
--- a/2.1.7/alpine3.11/Dockerfile
+++ b/2.1.7/alpine3.11/Dockerfile
@@ -27,4 +27,5 @@ RUN set -eux; \
 
 COPY nats-server.conf /etc/nats/nats-server.conf
 EXPOSE 4222 8222 6222
-CMD ["nats-server"]
+ENTRYPOINT ["nats-server"]
+CMD ["--config", "/etc/nats/nats-server.conf"]


### PR DESCRIPTION
Unlike the scratch, the Alpine docker was not starting the server
with the embedded config file.

Resolves #36

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>