### PR TITLE
Use proper arch name on Alpine for arm64 architecture

### DIFF
--- a/2.1.7/alpine3.11/Dockerfile
+++ b/2.1.7/alpine3.11/Dockerfile
@@ -5,7 +5,7 @@ ENV NATS_SERVER 2.1.7
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64|arm64) natsArch='arm64'; sha256='a08d7ce0399df8701d3e3cd4c36744180c3a566cdb38efeccc12a364f0083705' ;; \
+		aarch64) natsArch='arm64'; sha256='a08d7ce0399df8701d3e3cd4c36744180c3a566cdb38efeccc12a364f0083705' ;; \
 		armhf) natsArch='arm6'; sha256='987c23f758842fb09c0d4500f632c5302aedc61d218f03998444b94074aabddb' ;; \
 		armv7) natsArch='arm7'; sha256='077fd1647aa25865ade5acc3d6ee5f542d2c62feb2fb41ec6d1dd83294bea05e' ;; \
 		x86_64) natsArch='amd64'; sha256='23cce53fe7f628f203dbbeadf434c3480d094690aba6ff0b1d374b8f2f9ffd8c' ;; \


### PR DESCRIPTION
Explanation is here:
https://github.com/docker-library/official-images/pull/8010#issuecomment-665852100
https://github.com/docker-library/official-images/pull/8010#issuecomment-665854650

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>