### PR TITLE
Add workflow for building preview release images

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,0 +1,88 @@
+name: Build Images
+
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  IMAGE_NAME: "synadia/nats-server"
+
+jobs:
+  linux-2_10:
+    if: ${{ startsWith(github.ref_name,  '2.10.') }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into Docker
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+        # Setting up Docker Buildx with docker-container driver is required
+        # at the moment to be able to use a subdirectory with Git context.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup builder
+        run: |
+          docker buildx create --name builder --bootstrap --use
+
+      - name: alpine3.19
+        run: |
+          docker buildx build \
+            --platform linux/arm64,linux/arm/v6,linux/arm/v7,linux/amd64,linux/386,linux/s390x \
+            --tag "${{ env.IMAGE_NAME }}:${{ github.ref_name }}-alpine3.19" \
+            --push \
+            ./2.10.x/alpine3.19
+
+      - name: scratch
+        run: |
+          docker buildx build \
+            --build-arg "BASE_IMAGE=${{ env.IMAGE_NAME }}:${{ github.ref_name }}-alpine3.19" \
+            --platform linux/arm64,linux/arm/v6,linux/arm/v7,linux/amd64,linux/386,linux/s390x \
+            --tag "${{ env.IMAGE_NAME }}:${{ github.ref_name }}-scratch" \
+            --push \
+            ./2.10.x/scratch
+
+  windows-2019-2_10:
+    if: ${{ startsWith(github.ref_name,  '2.10.') }}
+    runs-on: windows-2019
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into Docker
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+        # Buildx is not supported on Windows yet.
+      - name: windowsservercore-1809
+        run: |
+          docker build `
+            --tag "${{ env.IMAGE_NAME }}:${{ github.ref_name }}-windowsservercore-1809" `
+            ./2.10.x/windowsservercore-1809
+
+          docker push "${{ env.IMAGE_NAME }}:${{ github.ref_name }}-windowsservercore-1809"
+
+      - name: nanoserver-1809
+        run: |
+          docker build `
+            --build-arg "BASE_IMAGE=${{ env.IMAGE_NAME }}:${{ github.ref_name }}-windowsservercore-1809" `
+            --tag "${{ env.IMAGE_NAME }}:${{ github.ref_name }}-nanoserver-1809" `
+            ./2.10.x/nanoserver-1809
+
+          docker push "${{ env.IMAGE_NAME }}:${{ github.ref_name }}-nanoserver-1809"

--- a/2.10.x/nanoserver-1809/Dockerfile
+++ b/2.10.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,10 @@
+ARG BASE_IMAGE=nats:2.10.10-windowsservercore-1809
+FROM $BASE_IMAGE AS base
+
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.10.10-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=base C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/scratch/Dockerfile
+++ b/2.10.x/scratch/Dockerfile
@@ -1,7 +1,10 @@
+ARG BASE_IMAGE=nats:2.10.10-alpine3.19
+FROM $BASE_IMAGE AS base
+
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.10.10-alpine3.19 /usr/local/bin/nats-server /nats-server
+COPY --from=base /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.9.x/nanoserver-1809/Dockerfile
+++ b/2.9.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,10 @@
+ARG BASE_IMAGE=nats:2.9.24-windowsservercore-1809
+FROM $BASE_IMAGE AS base
+
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.9.24-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=base C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.9.x/scratch/Dockerfile
+++ b/2.9.x/scratch/Dockerfile
@@ -1,7 +1,10 @@
+ARG BASE_IMAGE=nats:2.9.24-alpine3.18
+FROM $BASE_IMAGE AS base
+
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.9.24-alpine3.18 /usr/local/bin/nats-server /nats-server
+COPY --from=base /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222


### PR DESCRIPTION
This does a multi-arch build for Linux and Windows equivalent to the official releases.

* Extract base image as build-time arg. This is necessary to
  override the official image name of "nats" to that of
  "synadia/nats-server" where these preview releases are pushed.

* The update.py script now supports -preview.x or -rc.x pre-release
  notation when updating the various files under 2.10.x.

Note, 2.9.x can be added as well, but the current scope is only the
current minor version.

This has been squashed, but was tested in previous commits, see:

- [Linux action](https://github.com/nats-io/nats-docker/actions/runs/7855146987/job/21436572887)
- [Windows action](https://github.com/nats-io/nats-docker/actions/runs/7855598788/job/21437476798)

See example pushed images on [Docker Hub](https://hub.docker.com/r/synadia/nats-server/tags?page=1&name=preview-images).