### PR TITLE
Update NATS 2.10.x -> 2.10.11

### DIFF
--- a/2.10.x/alpine3.19/Dockerfile
+++ b/2.10.x/alpine3.19/Dockerfile
@@ -1,16 +1,17 @@
 FROM alpine:3.19
 
-ENV NATS_SERVER 2.10.10
+ENV NATS_SERVER 2.10.11
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='bbf8b7bc850580a370c9309d0e43ea2b2286e21fa9f5b33dfb751d219275e9e0' ;; \
-		armhf) natsArch='arm6'; sha256='9750cf2efb47afd8965a1ec9cd2a96c6d6af0cae70cfefc7b425e030799e1ac5' ;; \
-		armv7) natsArch='arm7'; sha256='3d9480c2bb3b0952f628d603855cbde234fe3768c498c5da89e11b8411d2be19' ;; \
-		x86_64) natsArch='amd64'; sha256='c8cd7e19b906a5f8a7f9f7e70fc4bfa492d66a069d9664c4db19fdee1b6aa640' ;; \
-		x86) natsArch='386'; sha256='99283c58577da02f6f9b0c104298308dfba18039dd48a782efc3be9d10b7bada' ;; \
-		s390x) natsArch='s390x'; sha256='e297977d1fc21c021aa989b1eda629dad9947d618558e14acc26f870ea86139a' ;; \
+		aarch64) natsArch='arm64'; sha256='52e603af6c249b716509ad7effb32033560e93578558c9e39420c15ab8d35fc5' ;; \
+		armhf) natsArch='arm6'; sha256='cf9d1668e00efba64e5f9bef36d950fcdfc99b99ec436282da2207ddbf63d35f' ;; \
+		armv7) natsArch='arm7'; sha256='582e77659441481f9a0dcd5bb3a8337137120448036db8601713b1769e19d1c2' ;; \
+		x86_64) natsArch='amd64'; sha256='4b85a83a8d3b5f919e4915fc68a43186eda37eb2f7b893c1690b3cabd1e24562' ;; \
+		x86) natsArch='386'; sha256='765acca88e27db4052b22eea63422f501e671a257da49bf955a54a52b2e314d4' ;; \
+		s390x) natsArch='s390x'; sha256='e534bcc6ee8d70090d8b60a0686970b1d6a0a79df2acdb32f367a4e9589e19ae' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='f0dd6e4c8c2e1c1bfc4c058e7461bb776e62473cc35f12c8db844e2a57d4eb1b' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.10.x/nanoserver-1809/Dockerfile
+++ b/2.10.x/nanoserver-1809/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.10-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.10.11-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.10.x/scratch/Dockerfile
+++ b/2.10.x/scratch/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.10-alpine3.19
+ARG BASE_IMAGE=nats:2.10.11-alpine3.19
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.10.x/tests/build-images-2019.ps1
+++ b/2.10.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.10.10'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.10.11'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.10.x/tests/build-images.sh
+++ b/2.10.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.10)
+ver=(NATS_SERVER 2.10.11)
 
 (
 	cd "../alpine3.19"

--- a/2.10.x/tests/run-images-2019.ps1
+++ b/2.10.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.10.10".Split(" ")[1]
+$ver = "NATS_SERVER 2.10.11".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.10.x/tests/run-images.sh
+++ b/2.10.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.10)
+ver=(NATS_SERVER 2.10.11)
 
 images=(
 	"nats:${ver[1]}-alpine3.19"

--- a/2.10.x/windowsservercore-1809/Dockerfile
+++ b/2.10.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.10.10
+ENV NATS_SERVER 2.10.11
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM d135040811bbf093dc9eb84df2db3c895d497133278e4db70f6f5b26b421838c
+ENV NATS_SERVER_SHASUM e788d206a4e87585cbfbe2cb63fb54ea90f60c5af2ddb3651b4abc0192ca659d
 
 RUN Set-PSDebug -Trace 2
 

--- a/update.py
+++ b/update.py
@@ -76,7 +76,7 @@ def update_alpine_shasums(base_dir: str, new_ver: str, shasums: typing.Dict):
     with open(file, "r") as fd:
         data = fd.read()
 
-    for arch in ["arm64", "arm6", "arm7", "amd64", "386", "s390x"]:
+    for arch in ["arm64", "arm6", "arm7", "amd64", "386", "s390x", "ppc64le"]:
         key = f"nats-server-v{new_ver}-linux-{arch}.tar.gz"
         arch_sha = shasums.get(key)
         r = re.compile(f"(natsArch='{arch}'; )"+r"sha256='" + sha256_str + r"'")


### PR DESCRIPTION
Also includes ppc64le arch build now that is available in the nats-server release.