### PR TITLE
Add net_bind_service capability to nats-server binary

### DIFF
--- a/2.10.x/alpine3.19/Dockerfile
+++ b/2.10.x/alpine3.19/Dockerfile
@@ -28,6 +28,10 @@ RUN set -eux; \
 COPY nats-server.conf /etc/nats/nats-server.conf
 COPY docker-entrypoint.sh /usr/local/bin
 
+RUN apk add --no-cache libcap \
+  && setcap cap_net_bind_service=+ep /usr/local/bin/nats-server \
+  && apk del libcap
+
 EXPOSE 4222 8222 6222
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["nats-server", "--config", "/etc/nats/nats-server.conf"]

--- a/2.11.x/alpine3.19/Dockerfile
+++ b/2.11.x/alpine3.19/Dockerfile
@@ -28,6 +28,10 @@ RUN set -eux; \
 COPY nats-server.conf /etc/nats/nats-server.conf
 COPY docker-entrypoint.sh /usr/local/bin
 
+RUN apk add --no-cache libcap \
+  && setcap cap_net_bind_service=+ep /usr/local/bin/nats-server \
+  && apk del libcap
+
 EXPOSE 4222 8222 6222
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["nats-server", "--config", "/etc/nats/nats-server.conf"]

--- a/2.9.x/alpine3.18/Dockerfile
+++ b/2.9.x/alpine3.18/Dockerfile
@@ -27,6 +27,10 @@ RUN set -eux; \
 COPY nats-server.conf /etc/nats/nats-server.conf
 COPY docker-entrypoint.sh /usr/local/bin
 
+RUN apk add --no-cache libcap \
+  && setcap cap_net_bind_service=+ep /usr/local/bin/nats-server \
+  && apk del libcap
+
 EXPOSE 4222 8222 6222
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["nats-server", "--config", "/etc/nats/nats-server.conf"]


### PR DESCRIPTION
I am trying to run nats in k8s as nonroot user and hostport mode. nats-server is listening to port 443 for wss protocol. This change allows nats-server to bind to port 443 .

The reason this is required is because k8s does not support ambient capabilities yet.
- https://github.com/kubernetes/enhancements/issues/2763
- https://github.com/kubernetes/kubernetes/issues/56374

ingress-nginx project also uses this in their Dockerfile to allow nonroot user
https://github.com/kubernetes/ingress-nginx/blob/48fbdfe3ba0c0e258890c970e2561caecea532dd/rootfs/Dockerfile#L70

Signed-off-by: Tamal Saha <tamal@appscode.com>