### PR TITLE
Releases v2.10.27-binary, v2.11.1-binary

### DIFF
--- a/2.10.x/alpine3.21/Dockerfile
+++ b/2.10.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.10.26
+ENV NATS_SERVER 2.10.27-binary
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='aba1b169f18d4441b4b5d760805c562dccc57b425a7a213a82753a2269a27235' ;; \
-		armhf) natsArch='arm6'; sha256='65a7003e8bfad9e8ba2d34efe8cc33299e754da2134d30b9cffb37561379f9b2' ;; \
-		armv7) natsArch='arm7'; sha256='85bfefdd849528df836da8820b46a088c20bbb7cf2ef90dfaa5211a789ac92be' ;; \
-		x86_64) natsArch='amd64'; sha256='6cbac67107e69c9e5a352d6f1555027f9da6a6b3fa81cceafefa9598b4451512' ;; \
-		x86) natsArch='386'; sha256='fc536de9e39ffe69f3f593e10c34d39a68c1ac98cfd88eff28f8c87dd09ec804' ;; \
-		s390x) natsArch='s390x'; sha256='c6f857d0dec8ea44f78efa3b4a7580fb51b7419e32b168bb1cb476527db04971' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='d416e0c151959ec896152ded12746e75ff549b9643dbec1e0087b0262c5b959a' ;; \
+		aarch64) natsArch='arm64'; sha256='2e6266b075c1f6905d974ead21ea65751125ec1f1c3a551152019755e5218c84' ;; \
+		armhf) natsArch='arm6'; sha256='b4f0613142539cf3260cfa6c7356dbbd3eea3020c5c01259ac7ff0af26809a86' ;; \
+		armv7) natsArch='arm7'; sha256='9f92594d9a3b52c2afb9ee107e168a62f1bc84a4f22defcaf8601c0a9c55bde7' ;; \
+		x86_64) natsArch='amd64'; sha256='5c9cd216cc0ce78092201a79e75a57607565d6e3aabad50305699dd468d579df' ;; \
+		x86) natsArch='386'; sha256='832a8e48a00ddccaef20602d364051d6f25790f0fc366187b1d5979b3c0cd1c9' ;; \
+		s390x) natsArch='s390x'; sha256='2562b3eb32a99a00dd8c9b0dfcd05d925cf1a09dd83d72268d2aa87c3f7e243f' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='48c7d863e614224268bf98ef47b221ca43d5be00c8ce44870d819ab50ba62f2b' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.10.x/nanoserver-1809/Dockerfile
+++ b/2.10.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.10.26-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.10.27-binary-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/nanoserver-1809/Dockerfile.preview
+++ b/2.10.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.26-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.10.27-binary-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.10.x/scratch/Dockerfile
+++ b/2.10.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.10.26-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.10.27-binary-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/scratch/Dockerfile.preview
+++ b/2.10.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.26-alpine3.21
+ARG BASE_IMAGE=nats:2.10.27-binary-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.10.x/tests/build-images-2019.ps1
+++ b/2.10.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.10.26'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.10.27-binary'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.10.x/tests/build-images.sh
+++ b/2.10.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.26)
+ver=(NATS_SERVER 2.10.27-binary)
 
 (
 	cd "../alpine3.21"

--- a/2.10.x/tests/run-images-2019.ps1
+++ b/2.10.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.10.26".Split(" ")[1]
+$ver = "NATS_SERVER 2.10.27-binary".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.10.x/tests/run-images.sh
+++ b/2.10.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.26)
+ver=(NATS_SERVER 2.10.27-binary)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.10.x/windowsservercore-1809/Dockerfile
+++ b/2.10.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.10.26
+ENV NATS_SERVER 2.10.27-binary
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM e1f9c4eee642bd521878dc493de8514b25c1468e3f2420312aa52f96f7bcbabf
+ENV NATS_SERVER_SHASUM 91a8ca4b87590a9915f7ccbb1064503dd2730c3c2e2b314c0ea4b59852a0c3cf
 
 RUN Set-PSDebug -Trace 2
 

--- a/2.11.x/alpine3.21/Dockerfile
+++ b/2.11.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.11.0
+ENV NATS_SERVER 2.11.1-binary
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='d286af6454cc78bd29acee5f46f212ee683adefab2694d338aeea0ba86e27f1b' ;; \
-		armhf) natsArch='arm6'; sha256='3d5edd81050b590ce1b7481a22601865dfaf486ad7d7f4b8b96e76ff7a667027' ;; \
-		armv7) natsArch='arm7'; sha256='bcc8bc70401258f4c4bbf992d1a5288a6ee037f5e7943de8fc23771bae43addb' ;; \
-		x86_64) natsArch='amd64'; sha256='8e486041359de5bb562c16604c3815d88d99efed77c338b1c96efa46856a8b98' ;; \
-		x86) natsArch='386'; sha256='1795f409990125677ba659b993bfd5a567b5c473d2dc2694aa47a55af669bc3a' ;; \
-		s390x) natsArch='s390x'; sha256='2c1ca2b6d8fb8a3560d906be7953a270164f7e7f7d23a63a8d579a7bc6e22a79' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='b8e542b5de2279c835a7d1f70c6cab26c9698e226156d3b6cfcb8f58edd6f243' ;; \
+		aarch64) natsArch='arm64'; sha256='2499105f9e64bef55f168f634d34a586b710f6ac041639d8a18364f2b4f4c410' ;; \
+		armhf) natsArch='arm6'; sha256='31bc11906458e30c8028cdd0301de98713074db73f5e352f58ce4ecd6b1cc641' ;; \
+		armv7) natsArch='arm7'; sha256='432f4c47cf5adca05da67f1feaf969f6cea50ed9c3bb743a8bb76b8c5c583c8e' ;; \
+		x86_64) natsArch='amd64'; sha256='827497f99acd54eb0e4e8bfa3b0eb31dd51c6c259110de11a45a7fdacae6c5b3' ;; \
+		x86) natsArch='386'; sha256='651065e2170ee0f7e244425c0d0ba30a38776a7aef75e2d5cba0b8b11a950c54' ;; \
+		s390x) natsArch='s390x'; sha256='23e6ce6b70f9b973106d325eebb8bdd613040bedd4da980ff0aea2d2a7dc122e' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='5341f41ef6298b05b72dd77c1ec055aeacb1b57dfd600ec888317347b3b4cbf8' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.11.x/nanoserver-1809/Dockerfile
+++ b/2.11.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.11.0-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.11.1-binary-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/nanoserver-1809/Dockerfile.preview
+++ b/2.11.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.0-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.11.1-binary-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.11.x/scratch/Dockerfile
+++ b/2.11.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.11.0-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.11.1-binary-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/scratch/Dockerfile.preview
+++ b/2.11.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.0-alpine3.21
+ARG BASE_IMAGE=nats:2.11.1-binary-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.11.x/tests/build-images-2019.ps1
+++ b/2.11.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.11.0'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.11.1-binary'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.11.x/tests/build-images.sh
+++ b/2.11.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.0)
+ver=(NATS_SERVER 2.11.1-binary)
 
 (
 	cd "../alpine3.21"

--- a/2.11.x/tests/run-images-2019.ps1
+++ b/2.11.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.11.0".Split(" ")[1]
+$ver = "NATS_SERVER 2.11.1-binary".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.11.x/tests/run-images.sh
+++ b/2.11.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.0)
+ver=(NATS_SERVER 2.11.1-binary)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.11.x/windowsservercore-1809/Dockerfile
+++ b/2.11.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.11.0
+ENV NATS_SERVER 2.11.1-binary
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM 131f8c47b421e6433ec0c193f68b29d2a0ef53365391dcd6c0f70740e8ec79ef
+ENV NATS_SERVER_SHASUM 2ab6b2c964fd5fe3b10a471cba309033f0756182f69228a65d1764197facf59c
 
 RUN Set-PSDebug -Trace 2
 


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>