### PR TITLE
Releases v2.10.27, v2.11.1

### DIFF
--- a/2.10.x/alpine3.21/Dockerfile
+++ b/2.10.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.10.27-binary
+ENV NATS_SERVER 2.10.27
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='2e6266b075c1f6905d974ead21ea65751125ec1f1c3a551152019755e5218c84' ;; \
-		armhf) natsArch='arm6'; sha256='b4f0613142539cf3260cfa6c7356dbbd3eea3020c5c01259ac7ff0af26809a86' ;; \
-		armv7) natsArch='arm7'; sha256='9f92594d9a3b52c2afb9ee107e168a62f1bc84a4f22defcaf8601c0a9c55bde7' ;; \
-		x86_64) natsArch='amd64'; sha256='5c9cd216cc0ce78092201a79e75a57607565d6e3aabad50305699dd468d579df' ;; \
-		x86) natsArch='386'; sha256='832a8e48a00ddccaef20602d364051d6f25790f0fc366187b1d5979b3c0cd1c9' ;; \
-		s390x) natsArch='s390x'; sha256='2562b3eb32a99a00dd8c9b0dfcd05d925cf1a09dd83d72268d2aa87c3f7e243f' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='48c7d863e614224268bf98ef47b221ca43d5be00c8ce44870d819ab50ba62f2b' ;; \
+		aarch64) natsArch='arm64'; sha256='47067e41dc27890d9665ddf429ce24f9ed50bddd035dee63b915fcfcb1f8043b' ;; \
+		armhf) natsArch='arm6'; sha256='4e4268d1bb83568217f8dbce77d5e0ca93cea8282d6fef796b505cdd2b16cb64' ;; \
+		armv7) natsArch='arm7'; sha256='a1dc4d8ff0a1e61aa80c9b50f5aa45dac3a3126e70d0c2ae5f53119dcf697503' ;; \
+		x86_64) natsArch='amd64'; sha256='0c3f53edaf1acccc41866d49d9c3626c9de8c9138b2fc11bbadfd3a4eb544ef1' ;; \
+		x86) natsArch='386'; sha256='f6b515da90da16bf09570d9dc67ef1488aaa75334c559c4c71371527242c5511' ;; \
+		s390x) natsArch='s390x'; sha256='f6864ce2b8fe25359ff9a307fabc88201e113b8c57634be2893d7bfafe425525' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='29c22b82c139baca9231c30f9a4a61f0f6df9407d67971c035a5ad45eb4296cf' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.10.x/nanoserver-1809/Dockerfile
+++ b/2.10.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.10.27-binary-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.10.27-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/nanoserver-1809/Dockerfile.preview
+++ b/2.10.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.27-binary-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.10.27-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.10.x/scratch/Dockerfile
+++ b/2.10.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.10.27-binary-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.10.27-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/scratch/Dockerfile.preview
+++ b/2.10.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.27-binary-alpine3.21
+ARG BASE_IMAGE=nats:2.10.27-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.10.x/tests/build-images-2019.ps1
+++ b/2.10.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.10.27-binary'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.10.27'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.10.x/tests/build-images.sh
+++ b/2.10.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.27-binary)
+ver=(NATS_SERVER 2.10.27)
 
 (
 	cd "../alpine3.21"

--- a/2.10.x/tests/run-images-2019.ps1
+++ b/2.10.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.10.27-binary".Split(" ")[1]
+$ver = "NATS_SERVER 2.10.27".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.10.x/tests/run-images.sh
+++ b/2.10.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.27-binary)
+ver=(NATS_SERVER 2.10.27)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.10.x/windowsservercore-1809/Dockerfile
+++ b/2.10.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.10.27-binary
+ENV NATS_SERVER 2.10.27
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM 91a8ca4b87590a9915f7ccbb1064503dd2730c3c2e2b314c0ea4b59852a0c3cf
+ENV NATS_SERVER_SHASUM f7033b98f4e063cc4790e3a1ec4853f2f5f6a474fea6090de8a04f851d46e277
 
 RUN Set-PSDebug -Trace 2
 

--- a/2.11.x/alpine3.21/Dockerfile
+++ b/2.11.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.11.1-binary
+ENV NATS_SERVER 2.11.1
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='2499105f9e64bef55f168f634d34a586b710f6ac041639d8a18364f2b4f4c410' ;; \
-		armhf) natsArch='arm6'; sha256='31bc11906458e30c8028cdd0301de98713074db73f5e352f58ce4ecd6b1cc641' ;; \
-		armv7) natsArch='arm7'; sha256='432f4c47cf5adca05da67f1feaf969f6cea50ed9c3bb743a8bb76b8c5c583c8e' ;; \
-		x86_64) natsArch='amd64'; sha256='827497f99acd54eb0e4e8bfa3b0eb31dd51c6c259110de11a45a7fdacae6c5b3' ;; \
-		x86) natsArch='386'; sha256='651065e2170ee0f7e244425c0d0ba30a38776a7aef75e2d5cba0b8b11a950c54' ;; \
-		s390x) natsArch='s390x'; sha256='23e6ce6b70f9b973106d325eebb8bdd613040bedd4da980ff0aea2d2a7dc122e' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='5341f41ef6298b05b72dd77c1ec055aeacb1b57dfd600ec888317347b3b4cbf8' ;; \
+		aarch64) natsArch='arm64'; sha256='27c90d8bc0ad10bfb38ef92bdea8528b4bfc5aa56afba91c790fb3921ea205a2' ;; \
+		armhf) natsArch='arm6'; sha256='8f9f2f4aa85c242f254a175c9455e9d00c6a0e7fc96b87a14ef3bd6d8762e900' ;; \
+		armv7) natsArch='arm7'; sha256='06dee81c2fd32639ae646112daaf9b84b71023bee88b16fd3324fd922095dda1' ;; \
+		x86_64) natsArch='amd64'; sha256='f1d9754bf34316d1f7d349b176ff0414c9cce742846bf2eec0b402eee35a638c' ;; \
+		x86) natsArch='386'; sha256='b746e832f96f07ee5958c99201b7a96695a3e1339f416342b9fd3c083a68dba7' ;; \
+		s390x) natsArch='s390x'; sha256='018ec95e10758c3e6ea14f034d3fe099234957dec8290bc5aa3480a8d77e3e29' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='be0f9308ffcdfa36189afdf7e8116235995d7d20406c0fc7b8aa5b5f724aa3d6' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.11.x/nanoserver-1809/Dockerfile
+++ b/2.11.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.11.1-binary-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.11.1-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/nanoserver-1809/Dockerfile.preview
+++ b/2.11.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.1-binary-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.11.1-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.11.x/scratch/Dockerfile
+++ b/2.11.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.11.1-binary-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.11.1-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/scratch/Dockerfile.preview
+++ b/2.11.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.1-binary-alpine3.21
+ARG BASE_IMAGE=nats:2.11.1-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.11.x/tests/build-images-2019.ps1
+++ b/2.11.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.11.1-binary'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.11.1'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.11.x/tests/build-images.sh
+++ b/2.11.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.1-binary)
+ver=(NATS_SERVER 2.11.1)
 
 (
 	cd "../alpine3.21"

--- a/2.11.x/tests/run-images-2019.ps1
+++ b/2.11.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.11.1-binary".Split(" ")[1]
+$ver = "NATS_SERVER 2.11.1".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.11.x/tests/run-images.sh
+++ b/2.11.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.1-binary)
+ver=(NATS_SERVER 2.11.1)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.11.x/windowsservercore-1809/Dockerfile
+++ b/2.11.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.11.1-binary
+ENV NATS_SERVER 2.11.1
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM 2ab6b2c964fd5fe3b10a471cba309033f0756182f69228a65d1764197facf59c
+ENV NATS_SERVER_SHASUM f5594798e1b77013b674c0049070d2502c20ee6f03a04d854cac333e2a21ca20
 
 RUN Set-PSDebug -Trace 2
 


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>