### PR TITLE
Releases v2.11.2-RC.2, v2.10.28-RC.2

### DIFF
--- a/2.10.x/alpine3.21/Dockerfile
+++ b/2.10.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.10.28-RC.1
+ENV NATS_SERVER 2.10.28-RC.2
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='71ded08861d856b6150ba464e6fce98f484a745116d6826f487356de6c9d6b74' ;; \
-		armhf) natsArch='arm6'; sha256='359cc36ad935ad0710712634354a5a106018121ffb685f05e5cf9b574a5aae2a' ;; \
-		armv7) natsArch='arm7'; sha256='6f9d3bd2a1fbbf9ea4ed7814df394c42bc570675d4be0e4fa2242b81e3582b8c' ;; \
-		x86_64) natsArch='amd64'; sha256='fa35baef07d44d1a7297eb38b39a855a43c9c4e424deed048c8e6ba3a3c741c1' ;; \
-		x86) natsArch='386'; sha256='5b2921ca77dc34931d703872919011798e98fa1dda641bd22b72aeb176ddc768' ;; \
-		s390x) natsArch='s390x'; sha256='71a35b5cc5f17789c2d5d85341bd6e97ca7596f4ac64489186b52fbdde252c9c' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='e6fdeccf94c11b19fc4757eedeb052d429310ee9a552266bb8f7404045f16f9f' ;; \
+		aarch64) natsArch='arm64'; sha256='4253c86914ef6759b527316886e15b6af046fe302413ab987edd096bdf02236a' ;; \
+		armhf) natsArch='arm6'; sha256='1c6c5b4b2cff13696affad77c2ebb228a4cfdfe159324c4cd356e1d65224d607' ;; \
+		armv7) natsArch='arm7'; sha256='4f7f10b172ba1a17f3e6d06e61baec86ac4f077575cf41dee70a9bc8144df393' ;; \
+		x86_64) natsArch='amd64'; sha256='65df3a8eda8f5838089a2a22276f19607912245a3d4d3bdd293c3146a8f06260' ;; \
+		x86) natsArch='386'; sha256='6af4e1b6e70c3fac904528bd78a8be4ce45d0f5d159e7242fb96bfa40e8d11e2' ;; \
+		s390x) natsArch='s390x'; sha256='0c46f2a0b2068b7c2831724b22c4dc3fa74be2d05acd7e70a420c9d577a20312' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='93b0e61abb37e04eb11d7b14af0b236e69cdf50694251183dc48a08487725613' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.10.x/nanoserver-1809/Dockerfile
+++ b/2.10.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.10.28-RC.1-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.10.28-RC.2-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/nanoserver-1809/Dockerfile.preview
+++ b/2.10.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.28-RC.1-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.10.28-RC.2-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.10.x/scratch/Dockerfile
+++ b/2.10.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.10.28-RC.1-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.10.28-RC.2-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/scratch/Dockerfile.preview
+++ b/2.10.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.28-RC.1-alpine3.21
+ARG BASE_IMAGE=nats:2.10.28-RC.2-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.10.x/tests/build-images-2019.ps1
+++ b/2.10.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.10.28-RC.1'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.10.28-RC.2'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.10.x/tests/build-images.sh
+++ b/2.10.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.28-RC.1)
+ver=(NATS_SERVER 2.10.28-RC.2)
 
 (
 	cd "../alpine3.21"

--- a/2.10.x/tests/run-images-2019.ps1
+++ b/2.10.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.10.28-RC.1".Split(" ")[1]
+$ver = "NATS_SERVER 2.10.28-RC.2".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.10.x/tests/run-images.sh
+++ b/2.10.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.28-RC.1)
+ver=(NATS_SERVER 2.10.28-RC.2)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.10.x/windowsservercore-1809/Dockerfile
+++ b/2.10.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.10.28-RC.1
+ENV NATS_SERVER 2.10.28-RC.2
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM 1d8727e6b72e5255a38794b2844e3714894a9a56442b5c894d7e06f3e475445b
+ENV NATS_SERVER_SHASUM 486accf754542465cad81f8b34f0921ed43362021234bd2d903841c769084492
 
 RUN Set-PSDebug -Trace 2
 

--- a/2.11.x/alpine3.21/Dockerfile
+++ b/2.11.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.11.2-RC.1
+ENV NATS_SERVER 2.11.2-RC.2
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='ccd818134cc7415c4b885cc330307aac2dce037100742a387869884c458a1e34' ;; \
-		armhf) natsArch='arm6'; sha256='40735fc61f71a927e95b22c40b5122588c5996e47177e05c0160f6761f5b17b1' ;; \
-		armv7) natsArch='arm7'; sha256='19fad8a7789fb1e0dbf0adad5ffcb2e9792e010285fc11821a604fdbd246da7f' ;; \
-		x86_64) natsArch='amd64'; sha256='6cc9bfd3b34275af7745ef2833aaf164b4d245dd339fd115277541de8dcee138' ;; \
-		x86) natsArch='386'; sha256='c4be0ced16789b5e9759f1d20ab3322a2d0b488bc6f42ce548d3af6b7978e435' ;; \
-		s390x) natsArch='s390x'; sha256='13029c8009078ede78a52dca2ea7bc1ec539a4ef94a0d231e08796e9bef2a42a' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='022c232a980372f7da8d5968e7f37341dccf2def1e10151480f13c955f14e3c5' ;; \
+		aarch64) natsArch='arm64'; sha256='4088a5bc78c50788b6da96e83dd2a9ac2100708a3991ed48ba6ba5234ecc5e4c' ;; \
+		armhf) natsArch='arm6'; sha256='f1d6a7670733fad68b9928028fa52e878336c9eca33fbc1d7ceb20c6c55b63e3' ;; \
+		armv7) natsArch='arm7'; sha256='0e6499c302a0733aec48e65bbfb7a498878fb533e6e6fb92c8eeb601fb7622d5' ;; \
+		x86_64) natsArch='amd64'; sha256='b0142b97c82f7e60df6f09f41b22baa677f6bf2cd5669328619a7fe8e9a623c1' ;; \
+		x86) natsArch='386'; sha256='332dc0f64fc5dda1e461339b038a9821509c1b78714d3b767122121117b2eb70' ;; \
+		s390x) natsArch='s390x'; sha256='8683a32d85286cc576757485a237288c2fd70d345ee22ee39b08ef55446e36a1' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='3a3b6eb6b81af66765c32309fe70104b51b3421889453929b3da843b3e22b8c4' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.11.x/nanoserver-1809/Dockerfile
+++ b/2.11.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.11.2-RC.1-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.11.2-RC.2-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/nanoserver-1809/Dockerfile.preview
+++ b/2.11.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.2-RC.1-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.11.2-RC.2-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.11.x/scratch/Dockerfile
+++ b/2.11.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.11.2-RC.1-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.11.2-RC.2-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/scratch/Dockerfile.preview
+++ b/2.11.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.2-RC.1-alpine3.21
+ARG BASE_IMAGE=nats:2.11.2-RC.2-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.11.x/tests/build-images-2019.ps1
+++ b/2.11.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.11.2-RC.1'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.11.2-RC.2'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.11.x/tests/build-images.sh
+++ b/2.11.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.2-RC.1)
+ver=(NATS_SERVER 2.11.2-RC.2)
 
 (
 	cd "../alpine3.21"

--- a/2.11.x/tests/run-images-2019.ps1
+++ b/2.11.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.11.2-RC.1".Split(" ")[1]
+$ver = "NATS_SERVER 2.11.2-RC.2".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.11.x/tests/run-images.sh
+++ b/2.11.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.2-RC.1)
+ver=(NATS_SERVER 2.11.2-RC.2)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.11.x/windowsservercore-1809/Dockerfile
+++ b/2.11.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.11.2-RC.1
+ENV NATS_SERVER 2.11.2-RC.2
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM cde79824b6182f252b8afbc0c73194d0911dac364c1cc97d357104239f9f5ddf
+ENV NATS_SERVER_SHASUM 0a6ee900297f64f254ab53d0bf7c4f2d1183d215aa6378d287dbf8fd474f977d
 
 RUN Set-PSDebug -Trace 2
 


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>