### PR TITLE
Releases v2.11.2, v2.10.28

### DIFF
--- a/2.10.x/alpine3.21/Dockerfile
+++ b/2.10.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.10.28-RC.3
+ENV NATS_SERVER 2.10.28
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='77e43dc18b8133cff6958bc79191994fdcbe96c1cfadad92dd6b9acc12b37a95' ;; \
-		armhf) natsArch='arm6'; sha256='762223826448e7701279a212301e27c1a973302d7c55b52c46d59473b9286067' ;; \
-		armv7) natsArch='arm7'; sha256='594f698fe4e453ec01b945cc36a74ba029c1631829cadeef9db9bd4d741c6d3e' ;; \
-		x86_64) natsArch='amd64'; sha256='82760e84e48bf3644055da500fc6eb740dd9546dd4f07f4c1b74f06ab18a1982' ;; \
-		x86) natsArch='386'; sha256='bea9e3d0d1a9fc94661a2c5e56a105648b50fd9f62c504137a2afd917a33affe' ;; \
-		s390x) natsArch='s390x'; sha256='8e18c2ae24230b939006f7d1b81b973ea668309c347f1b4271dad62d1c72e300' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='aaff4b6941278bd2ed0a11debfaf13005281f98f58b68253ed5ac65e4ab9b263' ;; \
+		aarch64) natsArch='arm64'; sha256='78f9b382d468f7b683bf8bdda2c6276de1fd230d9d19724485f48b327d7ed4c2' ;; \
+		armhf) natsArch='arm6'; sha256='2a29a87abdec21bff9fb19a30aa06af12a6db31ec32d0b3de1a7c8bdeeb74b19' ;; \
+		armv7) natsArch='arm7'; sha256='837db6e72894993bde7f0e402f6f9dc151d8452b0441cea630260764bafd4c84' ;; \
+		x86_64) natsArch='amd64'; sha256='52e3baee2bf9cb4f3d362e293538e9f11ccfdb22ac9fbbd2bcad790e3ba41e3e' ;; \
+		x86) natsArch='386'; sha256='ffabdd7c124951b68ed4501223d5a877c3e90c5da68c27c884a58806eaa1c369' ;; \
+		s390x) natsArch='s390x'; sha256='f5627e4db5746200f62e6d5d9212dcfc59a4d4dc9cee30abf8eafdafac5445a1' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='096424d6958c7b2798027208d0cc0c2ea5632e5530fd94d66712d586ca6d6d27' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.10.x/nanoserver-1809/Dockerfile
+++ b/2.10.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.10.28-RC.3-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.10.28-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/nanoserver-1809/Dockerfile.preview
+++ b/2.10.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.28-RC.3-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.10.28-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.10.x/scratch/Dockerfile
+++ b/2.10.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.10.28-RC.3-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.10.28-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/scratch/Dockerfile.preview
+++ b/2.10.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.28-RC.3-alpine3.21
+ARG BASE_IMAGE=nats:2.10.28-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.10.x/tests/build-images-2019.ps1
+++ b/2.10.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.10.28-RC.3'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.10.28'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.10.x/tests/build-images.sh
+++ b/2.10.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.28-RC.3)
+ver=(NATS_SERVER 2.10.28)
 
 (
 	cd "../alpine3.21"

--- a/2.10.x/tests/run-images-2019.ps1
+++ b/2.10.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.10.28-RC.3".Split(" ")[1]
+$ver = "NATS_SERVER 2.10.28".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.10.x/tests/run-images.sh
+++ b/2.10.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.28-RC.3)
+ver=(NATS_SERVER 2.10.28)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.10.x/windowsservercore-1809/Dockerfile
+++ b/2.10.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.10.28-RC.3
+ENV NATS_SERVER 2.10.28
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM f1b25c59101ff3d12d8db71b070e9383131305d6ed22107500a9f9bd77e1cbf7
+ENV NATS_SERVER_SHASUM 98b8571231b00ebe0445cc7f317f6425c1fbc2edecd455949d37022e04281657
 
 RUN Set-PSDebug -Trace 2
 

--- a/2.11.x/alpine3.21/Dockerfile
+++ b/2.11.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.11.2-RC.3
+ENV NATS_SERVER 2.11.2
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='432801ff1367defce7c3d88d3e82373537283b175bc1ea2e925082d66876a80c' ;; \
-		armhf) natsArch='arm6'; sha256='cee98d7522e66243caa773176e0f0d3b602a5b52e9b8f375362ee3fdc6bdfce0' ;; \
-		armv7) natsArch='arm7'; sha256='cc63788e5955d77da820f0e8ea0854bba810ca8e5cb4e1893c417590d876bddf' ;; \
-		x86_64) natsArch='amd64'; sha256='d77d185386f63715d587ab3b1d2c527b6706ea1f3ad1edc8181262cf11c05156' ;; \
-		x86) natsArch='386'; sha256='888004cc0f1df6e08c0de59a28316a55e0993ca2a4cac4171ede60aaea760054' ;; \
-		s390x) natsArch='s390x'; sha256='b170c6d9ffeef32339e503b14f8eed4b4456047e7753c3f32511145a493d521c' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='594e3176cfccc869c62876ccc944cb2c857d55513badd9a53f1a98410a3c6b22' ;; \
+		aarch64) natsArch='arm64'; sha256='da0a4b9d57d2a4c2439f0c8731b7e1ef8f0a7f2a1edf643d5f50a73ffc0c31f9' ;; \
+		armhf) natsArch='arm6'; sha256='2370e8d794acb0f176be0f0885f9930fa9d8d1276f15162eb8db336467279bc1' ;; \
+		armv7) natsArch='arm7'; sha256='46b038e57ad586f05342dcd3b29a2c2597217c19172a916eef9187170f024ad8' ;; \
+		x86_64) natsArch='amd64'; sha256='a123c8e43abe5ca8f0bff9393547f20f4bbac6fc0fb3c586ec031855911c414a' ;; \
+		x86) natsArch='386'; sha256='03bf7db9323c453b1257c3a43a21fcd5a975a2cc136c4bbeab7c0e815939e37e' ;; \
+		s390x) natsArch='s390x'; sha256='eb40e4a843124198b7e8625b7cccbd52810d63db17e1557d59681f5f29be5a98' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='28e2afbca41dffe453507a993291560bfc57c6f43fe435604f894c3d91426dd0' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.11.x/nanoserver-1809/Dockerfile
+++ b/2.11.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.11.2-RC.3-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.11.2-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/nanoserver-1809/Dockerfile.preview
+++ b/2.11.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.2-RC.3-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.11.2-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.11.x/scratch/Dockerfile
+++ b/2.11.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.11.2-RC.3-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.11.2-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/scratch/Dockerfile.preview
+++ b/2.11.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.2-RC.3-alpine3.21
+ARG BASE_IMAGE=nats:2.11.2-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.11.x/tests/build-images-2019.ps1
+++ b/2.11.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.11.2-RC.3'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.11.2'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.11.x/tests/build-images.sh
+++ b/2.11.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.2-RC.3)
+ver=(NATS_SERVER 2.11.2)
 
 (
 	cd "../alpine3.21"

--- a/2.11.x/tests/run-images-2019.ps1
+++ b/2.11.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.11.2-RC.3".Split(" ")[1]
+$ver = "NATS_SERVER 2.11.2".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.11.x/tests/run-images.sh
+++ b/2.11.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.2-RC.3)
+ver=(NATS_SERVER 2.11.2)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.11.x/windowsservercore-1809/Dockerfile
+++ b/2.11.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.11.2-RC.3
+ENV NATS_SERVER 2.11.2
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM 8851ae2cfceb5b3750f6a611f994eadf22f8e09903076a9fc734fcbda5f8b9f0
+ENV NATS_SERVER_SHASUM 27bc84446495ed13983a86044d77cc24e4d5661a3ea3caaff3003c2d19dc3db8
 
 RUN Set-PSDebug -Trace 2
 


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>