### PR TITLE
Releases v2.11.3-RC.1, v2.10.29-RC.1

### DIFF
--- a/2.10.x/alpine3.21/Dockerfile
+++ b/2.10.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.10.28
+ENV NATS_SERVER 2.10.29-RC.1
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='78f9b382d468f7b683bf8bdda2c6276de1fd230d9d19724485f48b327d7ed4c2' ;; \
-		armhf) natsArch='arm6'; sha256='2a29a87abdec21bff9fb19a30aa06af12a6db31ec32d0b3de1a7c8bdeeb74b19' ;; \
-		armv7) natsArch='arm7'; sha256='837db6e72894993bde7f0e402f6f9dc151d8452b0441cea630260764bafd4c84' ;; \
-		x86_64) natsArch='amd64'; sha256='52e3baee2bf9cb4f3d362e293538e9f11ccfdb22ac9fbbd2bcad790e3ba41e3e' ;; \
-		x86) natsArch='386'; sha256='ffabdd7c124951b68ed4501223d5a877c3e90c5da68c27c884a58806eaa1c369' ;; \
-		s390x) natsArch='s390x'; sha256='f5627e4db5746200f62e6d5d9212dcfc59a4d4dc9cee30abf8eafdafac5445a1' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='096424d6958c7b2798027208d0cc0c2ea5632e5530fd94d66712d586ca6d6d27' ;; \
+		aarch64) natsArch='arm64'; sha256='850babec8d23d5edf678fb5e3d7fa441eb885f5bdf14b6811c25770280543fb9' ;; \
+		armhf) natsArch='arm6'; sha256='9dca25c4dc78446b24568af7dba2b9f79599608c22755aa9c0b4e6232f81f6a7' ;; \
+		armv7) natsArch='arm7'; sha256='a8bb844bb68ee2d6e34ccd186e2dcd98ef3041d0ee3456066bf094d786b0d115' ;; \
+		x86_64) natsArch='amd64'; sha256='ea984cc71f3a015cd3b65e4fe093f6088a91ad5c60456fe9a2a844d4e9ae5c08' ;; \
+		x86) natsArch='386'; sha256='f6454d51ba1adb0c1a70e3d375228d059bb8ba2b24b8771b1ca26a36dbc53229' ;; \
+		s390x) natsArch='s390x'; sha256='323b3f0595cbb1ff940a32e2b849d9a7063cdb49bfccedd18e22f1d650b38b83' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='dbbd4006d8f4145fb9ae9ed966d7c5474b67686fab4769ebbcba960abb8f7264' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.10.x/nanoserver-1809/Dockerfile
+++ b/2.10.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.10.28-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.10.29-RC.1-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/nanoserver-1809/Dockerfile.preview
+++ b/2.10.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.28-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.10.29-RC.1-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.10.x/scratch/Dockerfile
+++ b/2.10.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.10.28-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.10.29-RC.1-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.10.x/scratch/Dockerfile.preview
+++ b/2.10.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.10.28-alpine3.21
+ARG BASE_IMAGE=nats:2.10.29-RC.1-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.10.x/tests/build-images-2019.ps1
+++ b/2.10.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.10.28'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.10.29-RC.1'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.10.x/tests/build-images.sh
+++ b/2.10.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.28)
+ver=(NATS_SERVER 2.10.29-RC.1)
 
 (
 	cd "../alpine3.21"

--- a/2.10.x/tests/run-images-2019.ps1
+++ b/2.10.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.10.28".Split(" ")[1]
+$ver = "NATS_SERVER 2.10.29-RC.1".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.10.x/tests/run-images.sh
+++ b/2.10.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.10.28)
+ver=(NATS_SERVER 2.10.29-RC.1)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.10.x/windowsservercore-1809/Dockerfile
+++ b/2.10.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.10.28
+ENV NATS_SERVER 2.10.29-RC.1
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM 98b8571231b00ebe0445cc7f317f6425c1fbc2edecd455949d37022e04281657
+ENV NATS_SERVER_SHASUM bf58cddd22a7268e4fed523c08450be1a1b985af3009bdd8b6dfcfbae4f84e92
 
 RUN Set-PSDebug -Trace 2
 

--- a/2.11.x/alpine3.21/Dockerfile
+++ b/2.11.x/alpine3.21/Dockerfile
@@ -1,17 +1,17 @@
 FROM alpine:3.21
 
-ENV NATS_SERVER 2.11.2
+ENV NATS_SERVER 2.11.3-RC.1
 
 RUN set -eux; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
-		aarch64) natsArch='arm64'; sha256='da0a4b9d57d2a4c2439f0c8731b7e1ef8f0a7f2a1edf643d5f50a73ffc0c31f9' ;; \
-		armhf) natsArch='arm6'; sha256='2370e8d794acb0f176be0f0885f9930fa9d8d1276f15162eb8db336467279bc1' ;; \
-		armv7) natsArch='arm7'; sha256='46b038e57ad586f05342dcd3b29a2c2597217c19172a916eef9187170f024ad8' ;; \
-		x86_64) natsArch='amd64'; sha256='a123c8e43abe5ca8f0bff9393547f20f4bbac6fc0fb3c586ec031855911c414a' ;; \
-		x86) natsArch='386'; sha256='03bf7db9323c453b1257c3a43a21fcd5a975a2cc136c4bbeab7c0e815939e37e' ;; \
-		s390x) natsArch='s390x'; sha256='eb40e4a843124198b7e8625b7cccbd52810d63db17e1557d59681f5f29be5a98' ;; \
-		ppc64le) natsArch='ppc64le'; sha256='28e2afbca41dffe453507a993291560bfc57c6f43fe435604f894c3d91426dd0' ;; \
+		aarch64) natsArch='arm64'; sha256='24e8843dd582891e85e7face26285e6e4c8bc9146da104a1098860ce45ddfda6' ;; \
+		armhf) natsArch='arm6'; sha256='176751dc2053e6ecef760152c027565632ef19e7f5cd8c1762d88bead4a24b06' ;; \
+		armv7) natsArch='arm7'; sha256='b028c8268817c8ef36227bfcbee207cdc9b6b008b3fab7f8515c8635bd75dbcb' ;; \
+		x86_64) natsArch='amd64'; sha256='8efc5d4346fbb02415d7a8e7cdec13c0658c1952fa1aa23f760021a19ef3479a' ;; \
+		x86) natsArch='386'; sha256='56495f1e35251c16cd4ef1e73a063eeacf647401cafb48eddca0599ecee112ac' ;; \
+		s390x) natsArch='s390x'; sha256='ae3f176b4bc54d38ff731851537011539daf120eac61be7876aad62173c3462d' ;; \
+		ppc64le) natsArch='ppc64le'; sha256='8b2f129ccba21f1d49c6be7b71e000483fcf5ed5bf5028684a568454a0f6d37d' ;; \
 		*) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
 	esac; \
 	\

--- a/2.11.x/nanoserver-1809/Dockerfile
+++ b/2.11.x/nanoserver-1809/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:1809
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.11.2-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.11.3-RC.1-windowsservercore-1809 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/nanoserver-1809/Dockerfile.preview
+++ b/2.11.x/nanoserver-1809/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.2-windowsservercore-1809
+ARG BASE_IMAGE=nats:2.11.3-RC.1-windowsservercore-1809
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:1809

--- a/2.11.x/scratch/Dockerfile
+++ b/2.11.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.11.2-alpine3.21 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.11.3-RC.1-alpine3.21 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.11.x/scratch/Dockerfile.preview
+++ b/2.11.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.11.2-alpine3.21
+ARG BASE_IMAGE=nats:2.11.3-RC.1-alpine3.21
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.11.x/tests/build-images-2019.ps1
+++ b/2.11.x/tests/build-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.11.2'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.11.3-RC.1'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.11.x/tests/build-images.sh
+++ b/2.11.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.2)
+ver=(NATS_SERVER 2.11.3-RC.1)
 
 (
 	cd "../alpine3.21"

--- a/2.11.x/tests/run-images-2019.ps1
+++ b/2.11.x/tests/run-images-2019.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.11.2".Split(" ")[1]
+$ver = "NATS_SERVER 2.11.3-RC.1".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-1809",

--- a/2.11.x/tests/run-images.sh
+++ b/2.11.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.11.2)
+ver=(NATS_SERVER 2.11.3-RC.1)
 
 images=(
 	"nats:${ver[1]}-alpine3.21"

--- a/2.11.x/windowsservercore-1809/Dockerfile
+++ b/2.11.x/windowsservercore-1809/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:1809
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.11.2
+ENV NATS_SERVER 2.11.3-RC.1
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM 27bc84446495ed13983a86044d77cc24e4d5661a3ea3caaff3003c2d19dc3db8
+ENV NATS_SERVER_SHASUM 8052746650d2c0979f780083d1b63e732267d313f016eded187f4f13a47bd060
 
 RUN Set-PSDebug -Trace 2
 


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>