### PR TITLE
Disable `loong64` in build pipeline until Alpine 3.22 is available for `linux/loong64`

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -11,7 +11,7 @@ permissions:
 env:
   IMAGE_NAME: "synadia/nats-server"
   LINUX_ARCHS_2_10: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/amd64,linux/386,linux/s390x,linux/ppc64le"
-  LINUX_ARCHS: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/amd64,linux/386,linux/s390x,linux/ppc64le,linux/loong64"
+  LINUX_ARCHS: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/amd64,linux/386,linux/s390x,linux/ppc64le"
 
 jobs:
   linux-2_10:


### PR DESCRIPTION
Signed-off-by: Neil Twigg <neil@nats.io>