### PR TITLE
Release v2.11.10 (Part 2)

### DIFF
--- a/2.12.x/alpine3.22/Dockerfile
+++ b/2.12.x/alpine3.22/Dockerfile
@@ -1,18 +1,18 @@
 FROM alpine:3.22
 
-ENV NATS_SERVER 2.12.1-RC.1
+ENV NATS_SERVER 2.12.0
 
 RUN set -eux; \
     apkArch="$(apk --print-arch)"; \
     case "$apkArch" in \
-    aarch64) natsArch='arm64'; sha256='517848a7f1e5a908c9f0e3f111ed1c6244d4f78ea40980b171fa57e0794848fc' ;; \
-    armhf) natsArch='arm6'; sha256='80afbbb0d2518a1330cb7b3d5e0656a7eb2ab78b5f860ea8c0d7d76628aa171e' ;; \
-    armv7) natsArch='arm7'; sha256='8946a66ecac2865820b927ecc48309d45b38a212a565143b216ccbf0a9829955' ;; \
-    x86_64) natsArch='amd64'; sha256='90fefc84b9bc641f1b90474f86b026ef90061ca4b591b291dcd4f099ee26a168' ;; \
-    x86) natsArch='386'; sha256='b71c165478988d1692ba782ba2ed9099dfc94ecb587722ea2e6f413b224ba8ec' ;; \
-    s390x) natsArch='s390x'; sha256='c6f26f034660ce699b3204584a10bb3a222c8b7a8e28f983c8e9a7edb2bc31a1' ;; \
-    ppc64le) natsArch='ppc64le'; sha256='c3f4706d861eedc88fb71a6998b470ffb551d1393bc0e3c39f2a1d08af45a94a' ;; \
-    loong64) natsArch='loong64'; sha256='5c4d074cd938998b07cfe39d387474eab9fafd98c14b34de6eec48a9abc726df' ;; \
+    aarch64) natsArch='arm64'; sha256='67051df32cd22ae830811ebb8574f431094e26a458fa7562e486b1cf37316915' ;; \
+    armhf) natsArch='arm6'; sha256='23a20ef82d9437c159a38c68f6e463545aaa7085286d104398ae71f0153d4a51' ;; \
+    armv7) natsArch='arm7'; sha256='82e0c757dff71c0593dc8ae45afadbf5bab5835b98134e9b2973750f9849ca6c' ;; \
+    x86_64) natsArch='amd64'; sha256='42f233b3e883ff96e9fa9ba0882b958138534bc5dd6c4da7318e296afc0da909' ;; \
+    x86) natsArch='386'; sha256='56eccfd5c4e9b3b31dae1bbe0c71b83cfb5a74f5990694dbc7557549df0f6c88' ;; \
+    s390x) natsArch='s390x'; sha256='c1902cd6faf29babd917bbffe1b287747659249ca4eefd2d786b0502524782c3' ;; \
+    ppc64le) natsArch='ppc64le'; sha256='2b7490b3b05392b69a8e55f8873a7be4663b03eecb0ca001ffcd97d1b3c91f8d' ;; \
+    loong64) natsArch='loong64'; sha256='d632ed768d645c0e58b0ff52eec14ff2a51c5f8690639457d4a92747ee9edc32' ;; \
     *) echo >&2 "error: $apkArch is not supported!"; exit 1 ;; \
     esac; \
     \

--- a/2.12.x/nanoserver-ltsc2022/Dockerfile
+++ b/2.12.x/nanoserver-ltsc2022/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.12.1-RC.1-windowsservercore-ltsc2022 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.12.0-windowsservercore-ltsc2022 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.12.x/nanoserver-ltsc2022/Dockerfile.preview
+++ b/2.12.x/nanoserver-ltsc2022/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.12.1-RC.1-windowsservercore-ltsc2022
+ARG BASE_IMAGE=nats:2.12.0-windowsservercore-ltsc2022
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/2.12.x/nanoserver-ltsc2025/Dockerfile
+++ b/2.12.x/nanoserver-ltsc2025/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2025
 ENV NATS_DOCKERIZED 1
 
-COPY --from=nats:2.12.1-RC.1-windowsservercore-ltsc2025 C:\\nats-server.exe C:\\nats-server.exe
+COPY --from=nats:2.12.0-windowsservercore-ltsc2025 C:\\nats-server.exe C:\\nats-server.exe
 COPY nats-server.conf C:\\nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.12.x/nanoserver-ltsc2025/Dockerfile.preview
+++ b/2.12.x/nanoserver-ltsc2025/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.12.1-RC.1-windowsservercore-ltsc2025
+ARG BASE_IMAGE=nats:2.12.0-windowsservercore-ltsc2025
 FROM $BASE_IMAGE AS base
 
 FROM mcr.microsoft.com/windows/nanoserver:ltsc2025

--- a/2.12.x/scratch/Dockerfile
+++ b/2.12.x/scratch/Dockerfile
@@ -1,7 +1,7 @@
 FROM scratch
 ENV PATH="$PATH:/"
 
-COPY --from=nats:2.12.1-RC.1-alpine3.22 /usr/local/bin/nats-server /nats-server
+COPY --from=nats:2.12.0-alpine3.22 /usr/local/bin/nats-server /nats-server
 COPY nats-server.conf /nats-server.conf
 
 EXPOSE 4222 8222 6222

--- a/2.12.x/scratch/Dockerfile.preview
+++ b/2.12.x/scratch/Dockerfile.preview
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nats:2.12.1-RC.1-alpine3.22
+ARG BASE_IMAGE=nats:2.12.0-alpine3.22
 FROM $BASE_IMAGE AS base
 
 FROM scratch

--- a/2.12.x/tests/build-images-ltsc2022.ps1
+++ b/2.12.x/tests/build-images-ltsc2022.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.12.1-RC.1'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.12.0'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.12.x/tests/build-images-ltsc2025.ps1
+++ b/2.12.x/tests/build-images-ltsc2025.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = 'NATS_SERVER 2.12.1-RC.1'.Split(' ')[1]
+$ver = 'NATS_SERVER 2.12.0'.Split(' ')[1]
 
 Write-Output '-- host info ---'
 Write-Output $PSVersionTable

--- a/2.12.x/tests/build-images.sh
+++ b/2.12.x/tests/build-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.12.1-RC.1)
+ver=(NATS_SERVER 2.12.0)
 
 (
 	cd "../alpine3.22"

--- a/2.12.x/tests/run-images-ltsc2022.ps1
+++ b/2.12.x/tests/run-images-ltsc2022.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.12.1-RC.1".Split(" ")[1]
+$ver = "NATS_SERVER 2.12.0".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-ltsc2022",

--- a/2.12.x/tests/run-images-ltsc2025.ps1
+++ b/2.12.x/tests/run-images-ltsc2025.ps1
@@ -3,7 +3,7 @@ Set-PSDebug -Trace 2
 # Exit on error.
 $ErrorActionPreference = "Stop"
 
-$ver = "NATS_SERVER 2.12.1-RC.1".Split(" ")[1]
+$ver = "NATS_SERVER 2.12.0".Split(" ")[1]
 
 $images = @(
 	"nats:${ver}-windowsservercore-ltsc2025",

--- a/2.12.x/tests/run-images.sh
+++ b/2.12.x/tests/run-images.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ver=(NATS_SERVER 2.12.1-RC.1)
+ver=(NATS_SERVER 2.12.0)
 
 images=(
 	"nats:${ver[1]}-alpine3.22"

--- a/2.12.x/windowsservercore-ltsc2022/Dockerfile
+++ b/2.12.x/windowsservercore-ltsc2022/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2022
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.12.1-RC.1
+ENV NATS_SERVER 2.12.0
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM b98a4420c4fd1e2a63dbbae65974b9347667b8be731dc539b7de453881e2f81c
+ENV NATS_SERVER_SHASUM 9e8a3a68f2f89e452d9777562e32f7f7604b0e4950f47b195d9192f2d8b35807
 
 RUN Set-PSDebug -Trace 2
 

--- a/2.12.x/windowsservercore-ltsc2025/Dockerfile
+++ b/2.12.x/windowsservercore-ltsc2025/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2025
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop';"]
 
 ENV NATS_DOCKERIZED 1
-ENV NATS_SERVER 2.12.1-RC.1
+ENV NATS_SERVER 2.12.0
 ENV NATS_SERVER_DOWNLOAD https://github.com/nats-io/nats-server/releases/download/v${NATS_SERVER}/nats-server-v${NATS_SERVER}-windows-amd64.zip
-ENV NATS_SERVER_SHASUM b98a4420c4fd1e2a63dbbae65974b9347667b8be731dc539b7de453881e2f81c
+ENV NATS_SERVER_SHASUM 9e8a3a68f2f89e452d9777562e32f7f7604b0e4950f47b195d9192f2d8b35807
 
 RUN Set-PSDebug -Trace 2
 


### PR DESCRIPTION
Revert 2.12.1-RC.1 to 2.12.0 for docker-library/official-images#15524, otherwise the builder gets upset that we have the RC tags named here but not in the library manifest.

Signed-off-by: Neil Twigg <neil@nats.io>